### PR TITLE
Setup codeclimate coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,13 @@ deploy:
   on:
     tags: true
     condition: "$TRAVIS_RUBY_VERSION == 2.3.4"
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+    > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - "./cc-test-reporter before-build"
+after_script:
+  - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
+env:
+  global:
+    secure: Rp2hkwHkNj2XRZMIYmOURJg2kGIVHxUqi1E8bLWaLF2pSPYXJ5UVMWAF9eoygUiJfh3Zy0vpGvkS2Uvh4CCL4rhWGqJ7sgCtq87q3ia589wvAePPrY8XrBsw2ZxCT+z+1E1YUZhojXZsl7YMIimLImgfz2yzrufddqUu5G2qhnHEEmJ7wpUs8M5hDwgNeBHrgY+YpPblg1O6I6m4eW3za/f4g/eAXuZcVQDtj9KGNkxOy5dxwZ3kcglXUu8U4Nf4osgJLAsUPgokeWxNHqS2PfUkR93lgK+wNHd4pNkVwq8Bh38moPYbsC+ZEh8wcGDRzPZUJNMYKCDVk/7haguV/KrF43xlczPhsT/iybBoiu4zwx3GsTS0xM/YgTfCxKA0f1kAM/CP+X56ccK0UMZ7BdAOa3PKhBVksK6ulL6WtajRL+wApl8RMCys31P4SUOS3amzT2ynWYv3JFWtp+0U8ZRoedeUMXbR+B403VrOQkAOUrO7omzztXyDNlsXey56w3E9EkTzwacXcaLhiBRBdz4Z7eaX9rfwGMLrQsWspNubqHsQjJkzEgi6kBbOXKR28Kq9rH6gzHzkVfHAzThWF9Jv8e6Lgfu+y0zoQXVRAY58wk8TIK6duzszHOEmkIy+3PumBhqurkYxOzjMz/5SkfK2o5d8ZZcPWoA0E1lYnnA=

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # guid_spanner
 
 [![Travis Status](https://travis-ci.org/Sage/guid_spanner.svg?branch=master)](https://travis-ci.org/Sage/guid_spanner)
-[![Code Climate](https://codeclimate.com/github/Sage/guid_spanner.png)](https://codeclimate.com/github/Sage/guid_spanner)
+[![Maintainability](https://api.codeclimate.com/v1/badges/8d12a8e1ea18edf6297c/maintainability)](https://codeclimate.com/github/Sage/guid_spanner/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/8d12a8e1ea18edf6297c/test_coverage)](https://codeclimate.com/github/Sage/guid_spanner/test_coverage)
 [![Gem Version](https://badge.fury.io/rb/guid_spanner.png)](http://badge.fury.io/rb/guid_spanner)
 
 Packs and unpacks 32(compact) and 36 charactor GUIDs

--- a/guid_spanner.gemspec
+++ b/guid_spanner.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+require 'simplecov'
+SimpleCov.start do
+  add_filter 'spec/'
+end
 
 require 'rspec'
 require 'pry'


### PR DESCRIPTION
* Setup CodeClimate coverage reporting - https://codeclimate.com/github/Sage/guid_spanner

📓 Code climate coverage reporting will only start when these changes have been merged to master.